### PR TITLE
Update setup.py method for retrieving the version of alluxio-py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,23 @@
 
 from setuptools import setup, find_packages
 
-import alluxio
+import os
+
+def get_version():
+    lines = open(os.path.join('alluxio', '__init__.py')).readlines()
+    vlines = [x for x in lines if '__version__' in x]
+    if len(vlines) != 1:
+        print(vlines)
+        raise Exception('No version found or too many versions found')
+    return vlines[0].replace('__version__', '').replace('=', '').strip(" '\"\n\t")
 
 
 setup(
     name='alluxio',
-    version=alluxio.__version__,
+    version=get_version(),
     description='Alluxio python client',
     long_description='Alluxio python client based on REST API',
-    url='https://github.com/TachyonNexus/alluxio-py',
+    url='https://github.com/Alluxio/alluxio-py',
     author='Alluxio, Inc',
     packages=find_packages(exclude=['docs', 'tests']),
     install_requires=['six', 'requests'],


### PR DESCRIPTION
The current method of specifying the version requires that the user
already have the `requests` module installed. This prevents adding
this module to any `requirements.txt` file.

Since other parts of the system actually use `alluxio.__version__`,
I have replaced how `setup.py` gets the current version. Using this
mechanism does this with minimal change to the rest of the tools.

I have also updated the project homepage to point to the correct
Github URL.