### PR TITLE
Alluxio error response uses 'statusCode' in JSON

### DIFF
--- a/alluxio/client.py
+++ b/alluxio/client.py
@@ -49,7 +49,7 @@ def _check_response(r):
     if r.status_code == requests.codes.ok:
         return
     error = r.json()
-    status = error['status']
+    status = error['statusCode']
     message = error['message']
     raise exceptions.new_alluxio_exception(status, message)
 


### PR DESCRIPTION
We often see stack traces like:

File "/opt/conda/envs/aggr/lib/python2.7/site-packages/alluxio/client.py", line 52, in _check_response
    status = error['status']
KeyError: 'status'

When Alluxio is trying to return a failure message, but the JSON response uses the key 'statusCode'.