### PR TITLE
Completely restructure json encode/decode.

### DIFF
--- a/alluxio/common.py
+++ b/alluxio/common.py
@@ -5,25 +5,56 @@ Commonly used classes throughout the entire Alluxio Python interface.
 import json
 import sys
 
+import attr
 from six import reraise
 
 
-class _JsonEncodable(object):
+def dict_by_values(items):
+    """Takes the output of `dictionary.items()` and transponses so that the value becomes the key"""
+    by_values = {}
+    for key, value in items:
+        by_values[value] = key
+    return by_values
+
+
+@attr.s
+class Jsonnable(object):
     """Base class for all classes that can be encoded into json."""
+
+    member_json_map = {}
+    member_list_map = {}
+
+    @property
+    def __dict__(self):
+        obj = {}
+        for field in attr.fields(self.__class__):
+            name = field.name
+            value = getattr(self, name, None)
+            if value is not None:
+                if isinstance(value, list):
+                    value = [vars(x) if hasattr(x, 'json') else x for x in value]
+                else:
+                    to_json = getattr(value, 'json', None)
+                    if callable(to_json):
+                        # This looks wrong. I'm getting the dict, and appending that, instead of getting the json
+                        # string. However, the json string for the object is the wrong choice. We need to append a json
+                        # serializeable object (the dict) instead of the string, since Alluxio won't unpack a json
+                        # string version of the dict. It expects the dict, so that's what we need to send.
+                        value = vars(value)
+                mapped = self.member_json_map.get(name, name)
+                obj[mapped] = value
+        return obj
+
+    def __str__(self):
+        """Return the json string representation of this object."""
+        return self.json()
 
     def json(self):
         """Convert the object into a python dict which can be encoded into a json string."""
-
-    def __repr__(self):
-        """Return the json string representation of this object."""
-        return json.dumps(self.json())
-
-
-class _JsonDecodable(object):  # pylint: disable=too-few-public-methods
-    """Base class for all classes that can be decoded from json."""
+        return json.dumps(vars(self))
 
     @classmethod
-    def from_json(cls, obj):
+    def from_json(cls, jsondata):
         """Return an instance of cls decoded from the json string obj.
 
         The implementation of in this base class just returns cls(str(obj)).
@@ -35,11 +66,32 @@ class _JsonDecodable(object):  # pylint: disable=too-few-public-methods
         Returns:
                 An instance of cls decoded from obj.
         """
+        by_values = dict_by_values(cls.member_json_map.items())
 
-        return cls(str(obj))
+        obj = cls()
+        decodedinput = json.loads(jsondata)
+        for key, value in decodedinput.items():
+            name = by_values.get(key, key)
+            converter = attr.fields_dict(cls)[name].converter
+            if callable(converter):
+                if isinstance(value, dict):
+                    # I need to get the next level down's list of `by_values` here.
+                    v_by_values = dict_by_values(converter().member_json_map.items())
+                    mapped = {}
+                    for v_name in value:
+                        mapped[v_by_values.get(v_name, v_name)] = value[v_name]
+                    value = converter(**(mapped))
+                else:
+                    value = converter(value)
+            if name in obj.member_list_map:
+                decoder = obj.member_list_map[name]
+                value = [decoder.from_json(json.dumps(x)) for x in value]
+            setattr(obj, name, value)
+        return obj
 
 
-class String(_JsonEncodable, _JsonDecodable):
+@attr.s
+class String(Jsonnable):
     """Base class for all classes that are type aliases of a str.
 
     Args:
@@ -49,15 +101,18 @@ class String(_JsonEncodable, _JsonDecodable):
         see :class:`alluxio.wire.Bits`.
     """
 
-    def __init__(self, name=''):
-        self.name = name
+    name = attr.ib(default='')
+
+    @property
+    def __dict__(self):
+        return self.name
 
     def json(self):
         return self.name
 
     @classmethod
-    def from_json(cls, obj):
-        return cls(str(obj))
+    def from_json(cls, jsondata):
+        return cls(str(jsondata).strip('"'))
 
 
 def raise_with_traceback(error_type, message):

--- a/alluxio/option.py
+++ b/alluxio/option.py
@@ -5,296 +5,189 @@ Notes:
     All classes in this module have a **json** method, which converts the class
     into a python dict that can be encoded into a json string.
 """
+import attr
+from .common import Jsonnable
+from .wire import mk_ttl_action, mk_read_type, mk_load_metadata_type, mk_write_type, mk_mode
 
-from .common import _JsonEncodable
 
-
-class CreateDirectory(_JsonEncodable):  # pylint: disable=too-few-public-methods
-    """Options to be used in :meth:`alluxio.Client.create_directory`.
-
-    Args:
-        allow_exists (bool): Whether the directory can already exist.
-        mode (:obj:`alluxio.wire.Mode`): The directory's access mode.
-        recursive (bool): Whether to create intermediate directories along the path as necessary.
-        write_type (:obj:`alluxio.wire.WriteType`): Where to create the directory,
-            e.g. in Alluxio only, in under storage only, or in both.
+@attr.s
+class CreateDirectory(Jsonnable):
     """
-    def __init__(self, **kwargs):
-        self.allow_exists = kwargs.get('allow_exists')
-        self.mode = kwargs.get('mode')
-        self.recursive = kwargs.get('recursive')
-        self.write_type = kwargs.get('write_type')
-
-    def json(self):
-        obj = {}
-        if self.allow_exists is not None:
-            obj['allowExists'] = self.allow_exists
-        if self.mode is not None:
-            obj['mode'] = self.mode.json()
-        if self.recursive is not None:
-            obj['recursive'] = self.recursive
-        if self.write_type is not None:
-            obj['writeType'] = self.write_type.json()
-        return obj
-
-
-class CreateFile(_JsonEncodable):  # pylint: disable=too-many-instance-attributes,too-few-public-methods
-    """Options to be used in :meth:`alluxio.Client.create_file`.
-
-    Args:
-        block_size_bytes (int): Block size of the file in bytes.
-        location_policy_class (str): The Java class name for the location policy.
-            If this is not specified, Alluxio will use the default value of the
-            property key **alluxio.user.file.write.location.policy.class**.
-        mode (:obj:`alluxio.wire.Mode`): The file's access mode.
-        recursive (bool): If True, creates intermediate directories along the
-            path as necessary.
-        ttl (int): The TTL (time to live) value. It identifies duration
-            (in milliseconds) the created file should be kept around before it
-            is automatically deleted. -1 means no TTL value is set.
-        ttl_action (:obj:`alluxio.wire.TTLAction`): The file action to take when
-            its TTL expires.
-        write_type (:obj:`alluxio.wire.WriteType`): It can be used to decide
-            where the file will be created, like in Alluxio only, or in
-            both Alluxio and under storage.
-        replication_durable (int): The number of block replication for durable write.
-        replication_max (int): The maximum number of block replication.
-        replication_min (int): The minimum number of block replication.
+    Options to be used in :meth:`alluxio.Client.create_directory`.
     """
+    allow_exists = attr.ib(default=None)  # (bool): Whether the directory can already exist.
+    mode = attr.ib(default=None)  # (:obj:`alluxio.wire.Mode`): The directory's access mode.
+    recursive = attr.ib(default=None)  # (bool): Whether to create intermediate directories along the path as necessary.
+    write_type = attr.ib(default=None)  # (:obj:`alluxio.wire.WriteType`): Where to create the directory, e.g. in
+    # Alluxio only, in under storage only, or in both.
 
-    def __init__(self, **kwargs):
-        self.block_size_bytes = kwargs.get('block_size_bytes')
-        self.location_policy_class = kwargs.get('location_policy_class')
-        self.mode = kwargs.get('mode')
-        self.recursive = kwargs.get('recursive')
-        self.ttl = kwargs.get('ttl')
-        self.ttl_action = kwargs.get('ttl_action')
-        self.write_type = kwargs.get('write_type')
-        self.replication_durable = kwargs.get('replication_durable')
-        self.replication_max = kwargs.get('replication_max')
-        self.replication_min = kwargs.get('replication_min')
-
-    def json(self):
-        obj = {}
-        if self.block_size_bytes is not None:
-            obj['blockSizeBytes'] = self.block_size_bytes
-        if self.location_policy_class is not None:
-            obj['locationPolicyClass'] = self.location_policy_class
-        if self.mode is not None:
-            obj['mode'] = self.mode.json()
-        if self.recursive is not None:
-            obj['recursive'] = self.recursive
-        if self.ttl is not None:
-            obj['ttl'] = self.ttl
-        if self.ttl_action is not None:
-            obj['ttlAction'] = self.ttl_action.json()
-        if self.write_type is not None:
-            obj['writeType'] = self.write_type.json()
-        if self.replication_durable is not None:
-            obj['replicationDurable'] = self.replication_durable
-        if self.replication_max is not None:
-            obj['replicationMax'] = self.replication_max
-        if self.replication_min is not None:
-            obj['replicationMin'] = self.replication_min
-        return obj
+    member_json_map = {
+        'allow_exists': 'allowExists',
+        'write_type': 'writeType',
+    }
 
 
-class Delete(_JsonEncodable):  # pylint: disable=too-few-public-methods
-    """Options to be used in :meth:`alluxio.Client.delete`.
+@attr.s  # pylint: disable=too-many-instance-attributes
+class CreateFile(Jsonnable):  # pylint: disable=too-many-instance-attributes
+    """
+    Options to be used in :meth:`alluxio.Client.create_file`.
+    """
+    block_size_bytes = attr.ib(default=None)  # (int): Block size of the file in bytes.
+    location_policy_class = attr.ib(default=None)  # (str): The Java class name for the location policy. If this is not
+    # specified, Alluxio will use the default value of the property
+    # key **alluxio.user.file.write.location.policy.class**.
+    mode = attr.ib(default=None, converter=mk_mode)  # (:obj:`alluxio.wire.Mode`): The file's access mode.
+    recursive = attr.ib(default=None)  # (bool): If True, creates intermediate directories along the path as necessary.
+    ttl = attr.ib(default=None)  # (int): The TTL (time to live) value. It identifies duration (in milliseconds) the
+    # created file should be kept around before it is automatically deleted. -1 means no TTL value is set.
+    ttl_action = attr.ib(default=None, converter=mk_ttl_action)  # (:obj:`alluxio.wire.TTLAction`): The file action to
+    # take when its TTL expires.
+    write_type = attr.ib(default=None, converter=mk_write_type)  # (:obj:`alluxio.wire.WriteType`): It can be used to
+    # decide where the file will be created, like in Alluxio only, or in both Alluxio and under storage.
+    replication_durable = attr.ib(default=None)  # (int): The number of block replication for durable write.
+    replication_max = attr.ib(default=None)  # (int): The maximum number of block replication.
+    replication_min = attr.ib(default=None)  # (int): The minimum number of block replication.
 
-    Args:
-        recursive (bool): If set to true for a path to a directory, the
-            directory and its contents will be deleted.
+    member_json_map = {
+        'block_size_bytes': 'blockSizeBytes',
+        'location_policy_class': 'locationPolicyClass',
+        'ttl_action': 'ttlAction',
+        'write_type': 'writeType',
+        'replication_durable': 'replicationDurable',
+        'replication_max': 'replicationMax',
+        'replication_min': 'replicationMin',
+    }
+
+
+@attr.s
+class Delete(Jsonnable):
+    """
+    Options to be used in :meth:`alluxio.Client.delete`.
     """
 
-    def __init__(self, **kwargs):
-        self.recursive = kwargs.get('recursive')
-
-    def json(self):
-        obj = {}
-        if self.recursive is not None:
-            obj['recursive'] = self.recursive
-        return obj
+    recursive = attr.ib(default=None)  # (bool): If set to true for a path to a directory, the directory and its
+    # contents will be deleted.
 
 
-class Exists(_JsonEncodable):  # pylint: disable=too-few-public-methods
+@attr.s
+class Exists(Jsonnable):
     """Options to be used in :meth:`alluxio.Client.exists`.
 
     Currently, it is an empty class, options may be added in future releases.
     """
 
 
-class Free(_JsonEncodable):  # pylint: disable=too-few-public-methods
-    """Options to be used in :meth:`alluxio.Client.free`.
-
-    Args:
-        recursive (bool): If set to true for a path to a directory, the
-            directory and its contents will be freed.
+@attr.s
+class Free(Jsonnable):
+    """
+    Options to be used in :meth:`alluxio.Client.free`.
     """
 
-    def __init__(self, **kwargs):
-        self.recursive = kwargs.get('recursive')
-
-    def json(self):
-        obj = {}
-        if self.recursive is not None:
-            obj['recursive'] = self.recursive
-        return obj
+    recursive = attr.ib(default=None)  # If set to true for a path to a directory, the directory and its contents will
+    # be freed.
 
 
-class GetStatus(_JsonEncodable):  # pylint: disable=too-few-public-methods
+@attr.s
+class GetStatus(Jsonnable):
     """Options to be used in :meth:`alluxio.Client.get_status`.
 
     Currently, it is an empty class, options may be added in future releases.
     """
 
 
-class ListStatus(_JsonEncodable):  # pylint: disable=too-few-public-methods
-    """Options to be used in :meth:`alluxio.Client.list_status`.
-
-    Args:
-        load_metadata_type (:class:`alluxio.wire.LoadMetadataType`): The type of
-            loading metadata, can be one of
-            :data:`alluxio.wire.LOAD_METADATA_TYPE_NEVER`,
-            :data:`alluxio.wire.LOAD_METADATA_TYPE_ONCE`,
-            :data:`alluxio.wire.LOAD_METADATA_TYPE_ALWAYS`,
-            see documentation on :class:`alluxio.wire.LoadMetadataType` for more
-            details
+@attr.s
+class ListStatus(Jsonnable):
+    """
+    Options to be used in :meth:`alluxio.Client.list_status`.
     """
 
-    def __init__(self, **kwargs):
-        self.load_metadata_type = kwargs.get('load_metadata_type')
-        self.recursive = kwargs.get('recursive')
+    load_metadata_type = attr.ib(default=None,
+                                 converter=mk_load_metadata_type)  # (:class:`alluxio.wire.LoadMetadataType`):
+    # The type of loading metadata, can be one of
+    #  :data:`alluxio.wire.LOAD_METADATA_TYPE_NEVER`,
+    #  :data:`alluxio.wire.LOAD_METADATA_TYPE_ONCE`,
+    #  :data:`alluxio.wire.LOAD_METADATA_TYPE_ALWAYS`,
+    #  see documentation on :class:`alluxio.wire.LoadMetadataType` for more details
+    recursive = attr.ib(default=None)
 
-    def json(self):
-        obj = {}
-        if self.load_metadata_type is not None:
-            obj['loadMetadataType'] = self.load_metadata_type.json()
-        if self.recursive is not None:
-            obj['recursive'] = self.recursive
-        return obj
+    member_json_map = {
+        'load_metadata_type': 'loadMetadataType'
+    }
 
 
-class Mount(_JsonEncodable):  # pylint: disable=too-few-public-methods
-    """Options to be used in :meth:`alluxio.Client.mount`.
-
-    Args:
-        properties (dict): A dictionary mapping property key strings to value strings.
-        read_only (bool): Whether the mount point is read-only.
-        shared (bool): Whether the mount point is shared with all Alluxio users.
+@attr.s
+class Mount(Jsonnable):
+    """
+    Options to be used in :meth:`alluxio.Client.mount`.
     """
 
-    def __init__(self, **kwargs):
-        self.properties = kwargs.get('properties')
-        self.read_only = kwargs.get('read_only')
-        self.shared = kwargs.get('shared')
+    properties = attr.ib(default=None)  # (dict): A dictionary mapping property key strings to value strings.
+    read_only = attr.ib(default=None)  # (bool): Whether the mount point is read-only.
+    shared = attr.ib(default=None)  # (bool): Whether the mount point is shared with all Alluxio users.
 
-    def json(self):
-        obj = {}
-        if self.properties is not None:
-            obj['properties'] = self.properties
-        if self.read_only is not None:
-            obj['readOnly'] = self.read_only
-        if self.shared is not None:
-            obj['shared'] = self.shared
-        return obj
+    member_json_map = {
+        'read_only': 'readOnly'
+    }
 
 
-class OpenFile(_JsonEncodable):  # pylint: disable=too-few-public-methods
-    """Options to be used in :meth:`alluxio.Client.open_file`.
-
-    Args:
-        cache_location_policy_class (str): The Java class name for the location
-            policy to be used when caching the opened file. If this is not
-            specified, Alluxio will use the default value of the property
-            key **alluxio.user.file.write.location.policy.class**.
-        max_ufs_read_concurrency (int): The maximum UFS read concurrency for
-            one block on one Alluxio worker.
-        read_type (:obj:`alluxio.wire.ReadType`): The read type, like whether
-            the file read should be cached, if this is not specified, Alluxio
-            will use the default value of the property key
-            **alluxio.user.file.readtype.default**.
-        ufs_read_location_policy_class (str): The Java class name for the
-            location policy to be used when reading from under storage. If this
-            is not specified, Alluxio will use the default value of the property
-            key **alluxio.user.ufs.block.read.location.policy**.
+@attr.s
+class OpenFile(Jsonnable):
+    """
+    Options to be used in :meth:`alluxio.Client.open_file`.
     """
 
-    def __init__(self, **kwargs):
-        self.cache_location_policy_class = kwargs.get(
-            'cache_location_policy_class')
-        self.max_ufs_read_concurrency = kwargs.get('max_ufs_read_concurrency')
-        self.read_type = kwargs.get('read_type')
-        self.ufs_read_location_policy_class = kwargs.get(
-            'ufs_read_location_policy_class')
+    cache_location_policy_class = attr.ib(default=None)  # (str): The Java class name for the location policy to be
+    # used when caching the opened file. If this is not specified, Alluxio will use the default value of the property
+    # key **alluxio.user.file.write.location.policy.class**.
+    max_ufs_read_concurrency = attr.ib(default=None)  # (int): The maximum UFS read concurrency for one block on one
+    # Alluxio worker.
+    read_type = attr.ib(default=None, converter=mk_read_type)  # (:obj:`alluxio.wire.ReadType`): The read type, like
+    # whether the file readshould be cached, if this is not specified, Alluxio will use the default value of the
+    # property key **alluxio.user.file.readtype.default**.
+    ufs_read_location_policy_class = attr.ib(default=None)  # (str): The Java class name for the location policy to be
+    # used when reading from under storage. If this is not specified, Alluxio will use the default value of the
+    # property key **alluxio.user.ufs.block.read.location.policy**.
 
-    def json(self):
-        obj = {}
-        if self.cache_location_policy_class is not None:
-            obj['cacheLocationPolicyClass'] = self.cache_location_policy_class
-        if self.max_ufs_read_concurrency is not None:
-            obj['maxUfsReadConcurrency'] = self.max_ufs_read_concurrency
-        if self.read_type is not None:
-            obj['readType'] = self.read_type.json()
-        if self.ufs_read_location_policy_class is not None:
-            obj['ufsReadLocationPolicyClass'] = self.ufs_read_location_policy_class
-        return obj
+    member_json_map = {
+        'cache_location_policy_class': 'cacheLocationPolicyClass',
+        'read_type': 'readType',
+        'max_ufs_read_concurrency': 'maxUfsReadConcurrency',
+        'ufs_read_location_policy_class': 'ufsReadLocationPolicyClass',
+    }
 
 
-class Rename(_JsonEncodable):  # pylint: disable=too-few-public-methods
+@attr.s
+class Rename(Jsonnable):
     """Options to be used in :meth:`alluxio.Client.rename`.
 
     Currently, it is an empty class, options may be added in future releases.
     """
 
 
-class SetAttribute(_JsonEncodable):  # pylint: disable=too-few-public-methods
-    """Options to be used in :meth:`alluxio.Client.set_attribute`.
-
-    Args:
-        owner (str): The owner of the path.
-        group (str): The group of the path.
-        mode (:obj:`alluxio.wire.Mode`): The access mode of the path.
-        pinned (bool): Whether the path is pinned in Alluxio, which means it
-            should be kept in memory.
-        recursive (bool): Whether to set ACL (access control list) recursively
-            under a directory.
-        ttl (int): The TTL (time to live) value. It identifies duration
-            (in milliseconds) the file should be kept around before it is
-            automatically deleted. -1 means no TTL value is set.
-        ttl_action (:obj:`alluxio.wire.TTLAction`): The file action to take when
-            its TTL expires.
+@attr.s
+class SetAttribute(Jsonnable):
+    """
+    Options to be used in :meth:`alluxio.Client.set_attribute`.
     """
 
-    def __init__(self, **kwargs):
-        self.owner = kwargs.get('owner')
-        self.group = kwargs.get('group')
-        self.mode = kwargs.get('mode')
-        self.pinned = kwargs.get('pinned')
-        self.recursive = kwargs.get('recursive')
-        self.ttl = kwargs.get('ttl')
-        self.ttl_action = kwargs.get('ttl_action')
+    owner = attr.ib(default=None)  # (str): The owner of the path.
+    group = attr.ib(default=None)  # (str): The group of the path.
+    mode = attr.ib(default='', converter=mk_mode)  # (:obj:`alluxio.wire.Mode`): The access mode of the path.
+    pinned = attr.ib(default=None)  # (bool): Whether the path is pinned in Alluxio, which means it should be kept in
+    # memory.
+    recursive = attr.ib(default=None)  # (bool): Whether to set ACL (access control list) recursively under a directory.
+    ttl = attr.ib(default=None)  # (int): The TTL (time to live) value. It identifies duration (in milliseconds) the
+    # file should be kept around before it is automatically deleted. -1 means no TTL value is set.
+    ttl_action = attr.ib(default='', converter=mk_ttl_action)  # (:obj:`alluxio.wire.TTLAction`): file action to take
+    # when its TTL expires.
 
-    def json(self):
-        obj = {}
-        if self.owner is not None:
-            obj['owner'] = self.owner
-        if self.group is not None:
-            obj['group'] = self.group
-        if self.mode is not None:
-            obj['mode'] = self.mode.json()
-        if self.pinned is not None:
-            obj['pinned'] = self.pinned
-        if self.recursive is not None:
-            obj['recursive'] = self.recursive
-        if self.ttl is not None:
-            obj['ttl'] = self.ttl
-        if self.ttl_action is not None:
-            obj['ttlAction'] = self.ttl_action.json()
-        return obj
+    member_json_map = {
+        'ttl_action': 'ttlAction',
+    }
 
 
-class Unmount(_JsonEncodable):  # pylint: disable=too-few-public-methods
+@attr.s
+class Unmount(Jsonnable):
     """Options to be used in :meth:`alluxio.Client.unmount`.
 
     Currently, it is an empty class, options may be added in future releases.

--- a/alluxio/tests/option_test.py
+++ b/alluxio/tests/option_test.py
@@ -5,9 +5,8 @@ from random_option import random_create_directory, random_create_file, random_de
 
 def test_create_directory():
     opt = random_create_directory()
-    print(opt.json())
     json = dict(allowExists=opt.allow_exists,
-                mode=opt.mode.json(),
+                mode=vars(opt.mode),
                 recursive=opt.recursive,
                 writeType=opt.write_type.json())
     assert_json_encode(opt, json)
@@ -17,7 +16,7 @@ def test_create_file():
     opt = random_create_file()
     json = dict(blockSizeBytes=opt.block_size_bytes,
                 locationPolicyClass=opt.location_policy_class,
-                mode=opt.mode.json(),
+                mode=vars(opt.mode),
                 recursive=opt.recursive,
                 ttl=opt.ttl,
                 ttlAction=opt.ttl_action.json(),
@@ -64,7 +63,7 @@ def test_open_file():
 
 def test_set_attribute():
     opt = random_set_attribute()
-    json = dict(owner=opt.owner, group=opt.group, mode=opt.mode.json(),
+    json = dict(owner=opt.owner, group=opt.group, mode=vars(opt.mode),
                 pinned=opt.pinned, recursive=opt.recursive, ttl=opt.ttl,
                 ttlAction=opt.ttl_action.json())
     assert_json_encode(opt, json)

--- a/alluxio/tests/random_option.py
+++ b/alluxio/tests/random_option.py
@@ -61,7 +61,6 @@ def random_set_attribute():
         group=random_str(),
         mode=random_mode(),
         owner=random_str(),
-        persisted=random_bool(),
         pinned=random_bool(),
         recursive=random_bool(),
         ttl=random_int(),

--- a/alluxio/tests/random_wire.py
+++ b/alluxio/tests/random_wire.py
@@ -26,8 +26,8 @@ def random_bits():
 
 
 def random_mode():
-    return wire.Mode(owner_bits=random_bits(), group_bits=random_bits(),
-                     other_bits=random_bits())
+    obj = wire.Mode(owner_bits=random_bits().name, group_bits=random_bits().name, other_bits=random_bits().name)
+    return obj
 
 
 def random_worker_net_address():
@@ -42,17 +42,13 @@ def random_block_location():
 
 
 def random_block_info():
-    locations = []
-    for _ in range(random.randint(1, 10)):
-        locations.append(random_block_location())
+    locations = [random_block_location() for _ in range(random.randint(1, 10))]
     return wire.BlockInfo(block_id=random_int(), length=random_int(),
                           locations=locations)
 
 
 def random_file_block_info():
-    ufs_locations = []
-    for _ in range(random.randint(1, 10)):
-        ufs_locations.append(random_str())
+    ufs_locations = [random_str() for _ in range(random.randint(1, 10))]
     return wire.FileBlockInfo(block_info=random_block_info(),
                               offset=random_int(), ufs_locations=ufs_locations)
 
@@ -99,23 +95,28 @@ def random_load_metadata_type():
 
 
 def random_file_info():
-    block_ids = []
-    for _ in range(random.randint(1, 10)):
-        block_ids.append(random_int())
-    file_block_infos = []
-    for _ in range(random.randint(1, 10)):
-        file_block_infos.append(random_file_block_info())
-    return wire.FileInfo(block_ids=block_ids, block_size_bytes=random_int(),
-                         cacheable=random_bool(), completed=random_bool(),
+    block_ids = [random_int() for _ in range(random.randint(1, 10))]
+    file_block_infos = [random_file_block_info() for _ in range(random.randint(1, 10))]
+    return wire.FileInfo(block_ids=block_ids,
+                         block_size_bytes=random_int(),
+                         cacheable=random_bool(),
+                         completed=random_bool(),
                          creation_time_ms=random_int(),
-                         file_block_infos=file_block_infos, file_id=random_int(),
-                         folder=random_bool(), group=random_str(),
+                         file_block_infos=file_block_infos,
+                         file_id=random_int(),
+                         folder=random_bool(),
+                         group=random_str(),
                          in_memory_percentage=random_int(),
                          last_modification_time_ms=random_int(),
-                         length=random_int(), mode=random_int(),
-                         mount_point=random_bool(), name=random_str(),
-                         owner=random_str(), path=random_str(),
+                         length=random_int(),
+                         mode=random_int(),
+                         mount_point=random_bool(),
+                         name=random_str(),
+                         owner=random_str(),
+                         path=random_str(),
                          persisted=random_bool(),
                          persistence_state=random_persistence_state(),
-                         pinned=random_bool(), ttl=random_int(),
-                         ttl_action=random_ttl_action(), ufs_path=random_str())
+                         pinned=random_bool(),
+                         ttl=random_int(),
+                         ttl_action=random_ttl_action(),
+                         ufs_path=random_str())

--- a/alluxio/tests/util.py
+++ b/alluxio/tests/util.py
@@ -1,3 +1,4 @@
+import json
 import random
 
 
@@ -10,13 +11,22 @@ def assert_string_subclass(obj, name):
 
 
 def assert_json_encode(obj, json_obj):
-    assert obj.json() == json_obj
+    d = vars(obj)
+    for key in d:
+        assert d[key] == json_obj[key], "{key}::{incorrect} != {correct}".format(key=key, incorrect=repr(d[key]),
+                                                                                 correct=repr(json_obj[key]))
+    assert d == json_obj
 
 
-def assert_json_decode(obj, json_str):
-    decoded = type(obj).from_json(json_str)
+def assert_json_decode(obj, json_dict):
+    decoded = type(obj).from_json(json.dumps(json_dict))
     assert type(decoded) == type(obj)
-    assert decoded.json() == obj.json()
+    d = vars(obj)
+    json_obj = vars(decoded)
+    for key in d:
+        assert d[key] == json_obj[key], "{key}::{incorrect} != {correct}".format(key=key, incorrect=repr(d[key]),
+                                                                                 correct=repr(json_obj[key]))
+    assert vars(decoded) == vars(obj)
 
 
 def random_bool():

--- a/alluxio/tests/wire_test.py
+++ b/alluxio/tests/wire_test.py
@@ -51,7 +51,7 @@ def test_worker_net_address():
 def test_block_location():
     location = random_block_location()
     json = dict(workerId=location.worker_id,
-                workerAddress=location.worker_address.json(),
+                workerAddress=vars(location.worker_address),
                 tierAlias=location.tier_alias)
     assert_json_encode(location, json)
     assert_json_decode(location, json)
@@ -60,14 +60,14 @@ def test_block_location():
 def test_block_info():
     block = random_block_info()
     json = dict(blockId=block.block_id, length=block.length,
-                locations=[location.json() for location in block.locations])
+                locations=[vars(location) for location in block.locations])
     assert_json_encode(block, json)
     assert_json_decode(block, json)
 
 
 def test_file_block_info():
     file_block_info = random_file_block_info()
-    json = dict(blockInfo=file_block_info.block_info.json(),
+    json = dict(blockInfo=vars(file_block_info.block_info),
                 offset=file_block_info.offset,
                 ufsLocations=file_block_info.ufs_locations)
     assert_json_encode(file_block_info, json)
@@ -76,8 +76,7 @@ def test_file_block_info():
 
 def test_mode():
     mode = random_mode()
-    json = dict(ownerBits=mode.owner_bits.json(),
-                groupBits=mode.group_bits.json(), otherBits=mode.other_bits.json())
+    json = vars(mode)
     assert_json_encode(mode, json)
     assert_json_decode(mode, json)
 
@@ -100,7 +99,7 @@ def test_file_info():
         completed=info.completed,
         creationTimeMs=info.creation_time_ms,
         lastModificationTimeMs=info.last_modification_time_ms,
-        fileBlockInfos=[block.json() for block in info.file_block_infos],
+        fileBlockInfos=[vars(block) for block in info.file_block_infos],
         fileId=info.file_id,
         folder=info.folder,
         owner=info.owner,

--- a/alluxio/wire.py
+++ b/alluxio/wire.py
@@ -7,7 +7,8 @@ dictionary that can be encoded into a json string. The **from_json** method
 decodes a json string into a class instance.
 """
 
-from .common import _JsonEncodable, _JsonDecodable, String
+import attr
+from .common import String, Jsonnable
 
 
 class Bits(String):
@@ -50,335 +51,6 @@ BITS_READ_WRITE = Bits('READ_WRITE')
 BITS_ALL = Bits('ALL')
 
 
-class BlockInfo(_JsonEncodable, _JsonDecodable):
-    """A block's information.
-
-    Args:
-        block_id (int): Block ID.
-        length (int): Block size in bytes.
-        locations (list of :obj:`alluxio.wire.BlockLocation`): List of file
-            block locations.
-    """
-
-    def __init__(self, block_id=0, length=0, locations=None):
-        self.block_id = block_id
-        self.length = length
-        self.locations = locations or []
-
-    def json(self):
-        return {
-            'blockId': self.block_id,
-            'length': self.length,
-            'locations': [location.json() for location in self.locations],
-        }
-
-    @classmethod
-    def from_json(cls, obj):
-        block_id = obj['blockId']
-        length = obj['length']
-        locations = obj['locations']
-        locations = [BlockLocation.from_json(
-            location) for location in locations]
-        return cls(block_id, length, locations)
-
-
-class WorkerNetAddress(_JsonEncodable, _JsonDecodable):
-    """Worker network address.
-
-    Args:
-        host (str): Worker's hostname.
-        rpc_port (int): Port of the worker's RPC server.
-        data_port (int): Port of the worker's data server.
-        web_port (int): Port of the worker's web server.
-    """
-
-    def __init__(self, host='', rpc_port=0, data_port=0, web_port=0):
-        self.host = host
-        self.rpc_port = rpc_port
-        self.data_port = data_port
-        self.web_port = web_port
-
-    def json(self):
-        return {
-            'host': self.host,
-            'rpcPort': self.rpc_port,
-            'dataPort': self.data_port,
-            'webPort': self.web_port,
-        }
-
-    @classmethod
-    def from_json(cls, obj):
-        addr = cls()
-        addr.host = obj['host']
-        addr.rpc_port = obj['rpcPort']
-        addr.data_port = obj['dataPort']
-        addr.web_port = obj['webPort']
-        return addr
-
-
-class BlockLocation(_JsonEncodable, _JsonDecodable):
-    """A block's location.
-
-    Args:
-        worker_id (int): ID of the worker that contains the block.
-        worker_address (:obj:`alluxio.wire.WorkerNetAddress`): Address of the
-            worker that contains the block.
-        tier_alias (str): Alias of the Alluxio storage tier that contains the
-            block, for example, MEM, SSD, or HDD.
-    """
-
-    def __init__(self, worker_id=0, worker_address=WorkerNetAddress(), tier_alias=''):
-        self.worker_id = worker_id
-        self.worker_address = worker_address
-        self.tier_alias = tier_alias
-
-    def json(self):
-        return {
-            'workerId': self.worker_id,
-            'workerAddress': self.worker_address.json(),
-            'tierAlias': self.tier_alias,
-        }
-
-    @classmethod
-    def from_json(cls, obj):
-        worker_id = obj['workerId']
-        worker_address = WorkerNetAddress.from_json(obj['workerAddress'])
-        tier_alias = obj['tierAlias']
-        return cls(worker_id, worker_address, tier_alias)
-
-
-class FileBlockInfo(_JsonEncodable, _JsonDecodable):
-    """A file block's information.
-
-    Args:
-        block_info (:obj:`alluxio.wire.BlockInfo`): The block's information.
-        offset (int): The block's offset in the file.
-        ufs_locations (list of str): The under storage locations that contain this block.
-    """
-
-    def __init__(self, block_info=BlockInfo(), offset=0, ufs_locations=None):
-        self.block_info = block_info
-        self.offset = offset
-        self.ufs_locations = ufs_locations or []
-
-    def json(self):
-        return {
-            'blockInfo': self.block_info.json(),
-            'offset': self.offset,
-            'ufsLocations': self.ufs_locations,
-        }
-
-    @classmethod
-    def from_json(cls, obj):
-        block_info = BlockInfo.from_json(obj['blockInfo'])
-        offset = obj['offset']
-        ufs_locations = obj['ufsLocations']
-        return cls(block_info, offset, ufs_locations)
-
-
-class FileInfo(_JsonEncodable, _JsonDecodable):  # pylint: disable=too-many-instance-attributes
-    """A file or directory's information.
-
-    Two :obj:`FileInfo` are comparable based on the attribute **name**. So a
-    list of :obj:`FileInfo` can be sorted by python's built-in **sort** function.
-
-    Args:
-        block_ids (list of int): List of block IDs.
-        block_size_bytes (int): Block size in bytes.
-        cacheable (bool): Whether the file can be cached in Alluxio.
-        completed (bool): Whether the file has been marked as completed.
-        creation_time_ms (int): The epoch time the file was created.
-        last_modification_time_ms (int):  The epoch time the file was last modified.
-        file_block_infos (list of :obj:`alluxio.wire.FileBlockInfo`): List of file block information.
-        file_id (int): File ID.
-        folder (bool): Whether this is a directory.
-        owner (str): Owner of this file or directory.
-        group (str): Group of this file or directory.
-        in_memory_percentage (int): Percentage of the in memory data.
-        length (int): File size in bytes.
-        name (str): File name.
-        path (str): Absolute file path.
-        ufs_path (str): Under storage path of this file.
-        pinned (bool): Whether the file is pinned.
-        persisted (bool): Whether the file is persisted.
-        persistence_state (:obj:`alluxio.wire.PersistenceState`): Persistence state.
-        mode (int): Access mode of the file or directory.
-        mount_point (bool): Whether this is a mount point.
-        ttl (int): The TTL (time to live) value. It identifies duration
-            (in milliseconds) the created file should be kept around before it
-            is automatically deleted. -1 means no TTL value is set.
-        ttl_action (:obj:`alluxio.wire.TTLAction`): The file action to take when
-            its TTL expires.
-    """
-
-    def __init__(self,   # pylint: disable=too-many-arguments,too-many-locals
-                 block_ids=None,
-                 block_size_bytes=0,
-                 cacheable=False,
-                 completed=False,
-                 creation_time_ms=0,
-                 last_modification_time_ms=0,
-                 file_block_infos=None,
-                 file_id=0,
-                 folder=False,
-                 owner='',
-                 group='',
-                 in_memory_percentage=0,
-                 length=0,
-                 name='',
-                 path='',
-                 ufs_path='',
-                 pinned=False,
-                 persisted=False,
-                 persistence_state='',
-                 mode=0,
-                 mount_point=False,
-                 ttl=0,
-                 ttl_action=''):
-        self.block_ids = block_ids or []
-        self.block_size_bytes = block_size_bytes
-        self.cacheable = cacheable
-        self.completed = completed
-        self.creation_time_ms = creation_time_ms
-        self.last_modification_time_ms = last_modification_time_ms
-        self.file_block_infos = file_block_infos or []
-        self.file_id = file_id
-        self.folder = folder
-        self.owner = owner
-        self.group = group
-        self.in_memory_percentage = in_memory_percentage
-        self.length = length
-        self.name = name
-        self.path = path
-        self.ufs_path = ufs_path
-        self.pinned = pinned
-        self.persisted = persisted
-        self.persistence_state = persistence_state
-        self.mode = mode
-        self.mount_point = mount_point
-        self.ttl = ttl
-        self.ttl_action = ttl_action
-
-    def __lt__(self, other):
-        return self.name < other.name
-
-    def __eq__(self, other):
-        return self.name == other.name
-
-    def __hash__(self):
-        return hash(self.name)
-
-    def json(self):
-        return {
-            'blockIds': self.block_ids,
-            'blockSizeBytes': self.block_size_bytes,
-            'cacheable': self.cacheable,
-            'completed': self.completed,
-            'creationTimeMs': self.creation_time_ms,
-            'lastModificationTimeMs': self.last_modification_time_ms,
-            'fileBlockInfos': [info.json() for info in self.file_block_infos],
-            'fileId': self.file_id,
-            'folder': self.folder,
-            'owner': self.owner,
-            'group': self.group,
-            'inMemoryPercentage': self.in_memory_percentage,
-            'length': self.length,
-            'name': self.name,
-            'path': self.path,
-            'ufsPath': self.ufs_path,
-            'pinned': self.pinned,
-            'persisted': self.persisted,
-            'persistenceState': self.persistence_state.json(),
-            'mode': self.mode,
-            'mountPoint': self.mount_point,
-            'ttl': self.ttl,
-            'ttlAction': self.ttl_action.json(),
-        }
-
-    @classmethod
-    def from_json(cls, obj):
-        info = cls()
-        info.block_ids = obj['blockIds']
-        info.block_size_bytes = obj['blockSizeBytes']
-        info.cacheable = obj['cacheable']
-        info.completed = obj['completed']
-        info.creation_time_ms = obj['creationTimeMs']
-        info.last_modification_time_ms = obj['lastModificationTimeMs']
-        info.file_block_infos = [FileBlockInfo.from_json(
-            block) for block in obj['fileBlockInfos']]
-        info.file_id = obj['fileId']
-        info.folder = obj['folder']
-        info.owner = obj['owner']
-        info.group = obj['group']
-        info.in_memory_percentage = obj['inMemoryPercentage']
-        info.length = obj['length']
-        info.name = obj['name']
-        info.path = obj['path']
-        info.ufs_path = obj['ufsPath']
-        info.pinned = obj['pinned']
-        info.persisted = obj['persisted']
-        info.persistence_state = PersistenceState.from_json(obj['persistenceState'])
-        info.mode = obj['mode']
-        info.mount_point = obj['mountPoint']
-        info.ttl = obj['ttl']
-        info.ttl_action = TTLAction.from_json(obj['ttlAction'])
-        return info
-
-
-class LoadMetadataType(String):
-    """The way to load metadata.
-
-    This can be one of the following, see their documentation for details:
-
-    * :data:`LOAD_METADATA_TYPE_NEVER`
-    * :data:`LOAD_METADATA_TYPE_ONCE`
-    * :data:`LOAD_METADATA_TYPE_ALWAYS`
-
-    Args:
-        name (str): The string representation of the way to load metadata.
-    """
-
-
-#: Never load metadata.
-LOAD_METADATA_TYPE_NEVER = LoadMetadataType('Never')
-#: Load metadata only at the first time of listing status on a directory.
-LOAD_METADATA_TYPE_ONCE = LoadMetadataType('Once')
-#: Always load metadata when listing status on a directory.
-LOAD_METADATA_TYPE_ALWAYS = LoadMetadataType('Always')
-
-
-class Mode(_JsonEncodable, _JsonDecodable):
-    """A file's access mode.
-
-    Args:
-        owner_bits (:obj:`alluxio.wire.Bits`): Access mode of the file's owner.
-        group_bits (:obj:`alluxio.wire.Bits`): Access mode of the users in the file's group.
-        other_bits (:obj:`alluxio.wire.Bits`): Access mode of others who are neither the owner nor in the group.
-    """
-
-    def __init__(self, owner_bits=Bits(), group_bits=Bits(), other_bits=Bits()):
-        # owner_bits represents the owner access mode
-        self.owner_bits = owner_bits
-        # group_bits represents the group access mode
-        self.group_bits = group_bits
-        # other_bits represents the other access mode
-        self.other_bits = other_bits
-
-    def json(self):
-        return {
-            'ownerBits': self.owner_bits.json(),
-            'groupBits': self.group_bits.json(),
-            'otherBits': self.other_bits.json(),
-        }
-
-    @classmethod
-    def from_json(cls, obj):
-        owner = Bits.from_json(obj['ownerBits'])
-        group = Bits.from_json(obj['groupBits'])
-        other = Bits.from_json(obj['otherBits'])
-        return cls(owner_bits=owner, group_bits=group, other_bits=other)
-
-
 class ReadType(String):
     """Convenience modes for commonly used read types.
 
@@ -406,6 +78,16 @@ READ_TYPE_CACHE = ReadType('CACHE')
 READ_TYPE_CACHE_PROMOTE = ReadType('CACHE_PROMOTE')
 
 
+def mk_read_type(name):
+    """
+    Used for `attrs` convertes, during decoding `from_json`. This allows to have the `from_json` avoid doing nested
+    types, such as a `Mode` that contains a `Mode` for the owner_bits attribute.
+    """
+    if isinstance(name, ReadType):
+        return name
+    return ReadType(name)
+
+
 class TTLAction(String):
     """Represent the file action to take when its TTL expires.
 
@@ -423,6 +105,16 @@ class TTLAction(String):
 TTL_ACTION_DELETE = TTLAction("DELETE")
 #: Represents the action of freeing a path.
 TTL_ACTION_FREE = TTLAction("FREE")
+
+
+def mk_ttl_action(name):
+    """
+    Used for `attrs` convertes, during decoding `from_json`. This allows to have the `from_json` avoid doing nested
+    types, such as a `Mode` that contains a `Mode` for the owner_bits attribute.
+    """
+    if isinstance(name, TTLAction):
+        return name
+    return TTLAction(name)
 
 
 class WriteType(String):
@@ -453,6 +145,16 @@ WRITE_TYPE_THROUGH = WriteType('THROUGH')
 WRITE_TYPE_ASYNC_THROUGH = WriteType('ASYNC_THROUGH')
 
 
+def mk_write_type(name):
+    """
+    Used for `attrs` convertes, during decoding `from_json`. This allows to have the `from_json` avoid doing nested
+    types, such as a `Mode` that contains a `Mode` for the owner_bits attribute.
+    """
+    if isinstance(name, WriteType):
+        return name
+    return WriteType(name)
+
+
 class PersistenceState(String):
     """Persistence state of a file.
 
@@ -476,3 +178,220 @@ PERSISTENCE_STATE_TO_BE_PERSISTED = PersistenceState('TO_BE_PERSISTED')
 PERSISTENCE_STATE_PERSISTED = PersistenceState('PERSISTED')
 #: File is lost but not persisted in the under FS.
 PERSISTENCE_STATE_LOST = PersistenceState('LOST')
+
+
+def mk_persistence_state(name):
+    """
+    Used for `attrs` convertes, during decoding `from_json`. This allows to have the `from_json` avoid doing nested
+    types, such as a `Mode` that contains a `Mode` for the owner_bits attribute.
+    """
+    if isinstance(name, PersistenceState):
+        return name
+    return PersistenceState(name)
+
+
+@attr.s
+class WorkerNetAddress(Jsonnable):
+    """
+    Worker network address.
+    """
+
+    member_json_map = {
+        'rpc_port': 'rpcPort',
+        'data_port': 'dataPort',
+        'web_port': 'webPort',
+    }
+
+    host = attr.ib(default='')  # (str): Worker's hostname.
+    rpc_port = attr.ib(default=0)  # (int): Port of the worker's RPC server.
+    data_port = attr.ib(default=0)  # (int): Port of the worker's data server.
+    web_port = attr.ib(default=0)  # (int): Port of the worker's web server.
+
+
+@attr.s
+class BlockLocation(Jsonnable):
+    """
+    A block's location.
+    """
+
+    member_json_map = {
+        'worker_id': 'workerId',
+        'worker_address': 'workerAddress',
+        'tier_alias': 'tierAlias',
+    }
+
+    worker_id = attr.ib(default=0)  # (int): ID of the worker that contains the block.
+    worker_address = attr.ib(factory=WorkerNetAddress, converter=WorkerNetAddress)
+    # (:obj:`alluxio.wire.WorkerNetAddress`): Address of the worker that contains the block.
+    tier_alias = attr.ib(default='')  # (str): Alias of the Alluxio storage tier that contains the block,
+    # for example, MEM, SSD, or HDD.
+
+
+@attr.s
+class BlockInfo(Jsonnable):
+    """
+    A block's information.
+    """
+
+    member_json_map = {
+        'block_id': 'blockId',
+    }
+
+    member_list_map = {
+        'locations': BlockLocation
+    }
+
+    block_id = attr.ib(default=0)  # (int): Block ID.
+    length = attr.ib(default=0)  # (int): Block size in bytes
+    locations = attr.ib(factory=list)  # (list of :obj:`alluxio.wire.BlockLocation`): List of file block locations.
+
+
+def mk_block_info(block_id=0, length=0, locations=None):
+    """
+    Used for `attrs` convertes, during decoding `from_json`. This allows to have the `from_json` avoid doing nested
+    types, such as a `Mode` that contains a `Mode` for the owner_bits attribute.
+    """
+    if isinstance(block_id, BlockInfo):
+        return block_id
+    return BlockInfo(block_id=block_id, length=length, locations=locations)
+
+
+@attr.s
+class FileBlockInfo(Jsonnable):
+    """
+    A file block's information.
+    """
+
+    member_json_map = {
+        'block_info': 'blockInfo',
+        'ufs_locations': 'ufsLocations',
+    }
+
+    block_info = attr.ib(factory=BlockInfo, converter=mk_block_info)  # (:obj:`alluxio.wire.BlockInfo`): The block's
+    # information.
+    offset = attr.ib(default=0)  # (int): The block's offset in the file.
+    ufs_locations = attr.ib(factory=list)  # (list of str): The under storage locations that contain this block.
+
+
+@attr.s(eq=False, order=False, hash=False)  # pylint: disable=too-many-instance-attributes
+class FileInfo(Jsonnable):  # pylint: disable=too-many-instance-attributes
+    """A file or directory's information.
+
+    Two :obj:`FileInfo` are comparable based on the attribute **name**. So a
+    list of :obj:`FileInfo` can be sorted by python's built-in **sort** function.
+    """
+    member_json_map = {
+        'persistence_state': 'persistenceState',
+        'ttl_action': 'ttlAction',
+        'file_id': 'fileId',
+        'block_ids': 'blockIds',
+        'block_size_bytes': 'blockSizeBytes',
+        'creation_time_ms': 'creationTimeMs',
+        'last_modification_time_ms': 'lastModificationTimeMs',
+        'file_block_infos': 'fileBlockInfos',
+        'in_memory_percentage': 'inMemoryPercentage',
+        'ufs_path': 'ufsPath',
+        'mount_point': 'mountPoint',
+    }
+
+    member_list_map = {
+        'file_block_infos': FileBlockInfo,
+    }
+
+    block_ids = attr.ib(factory=list)  # (list of int): List of block IDs.
+    block_size_bytes = attr.ib(default=0)  # (int): Block size in bytes.
+    cacheable = attr.ib(default=False)  # (bool): Whether the file can be cached in Alluxio.
+    completed = attr.ib(default=False)  # (bool): Whether the file has been marked as completed.
+    creation_time_ms = attr.ib(default=0)  # (int): The epoch time the file was created.
+    last_modification_time_ms = attr.ib(default=0)  # (int):  The epoch time the file was last modified.
+    file_block_infos = attr.ib(factory=list)  # (list of :obj:`alluxio.wire.FileBlockInfo`): List of file block
+    # information.
+    file_id = attr.ib(default=0)  # (int): File ID.
+    folder = attr.ib(default=False)  # (bool): Whether this is a directory.
+    owner = attr.ib(default='')  # (str): Owner of this file or directory.
+    group = attr.ib(default='')  # (str): Group of this file or directory.
+    in_memory_percentage = attr.ib(default=0)  # (int): Percentage of the in memory data.
+    length = attr.ib(default=0)  # (int): File size in bytes.
+    name = attr.ib(default='')  # (str): File name.
+    path = attr.ib(default='')  # (str): Absolute file path.
+    ufs_path = attr.ib(default='')  # (str): Under storage path of this file.
+    pinned = attr.ib(default=False)  # (bool): Whether the file is pinned.
+    persisted = attr.ib(default=False)  # (bool): Whether the file is persisted.
+    persistence_state = attr.ib(factory=PersistenceState, converter=mk_persistence_state)
+    # (:obj:`alluxio.wire.PersistenceState`): Persistence state.
+    mode = attr.ib(default=0)  # (int): Access mode of the file or directory.
+    mount_point = attr.ib(default=False)  # (bool): Whether this is a mount point.
+    ttl = attr.ib(default=0)  # (int): The TTL (time to live) value. It identifies duration (in milliseconds) the
+    # created file should be kept around before it is automatically deleted. -1 means no TTL value is set.
+    ttl_action = attr.ib(factory=TTLAction, converter=mk_ttl_action)  # (:obj:`alluxio.wire.TTLAction`): The file action
+    # to take when its TTL expires.
+
+    def __lt__(self, other):
+        return self.name < other.name
+
+    def __eq__(self, other):
+        return self.name == other.name
+
+    def __hash__(self):
+        return hash(self.name)
+
+
+class LoadMetadataType(String):
+    """The way to load metadata.
+
+    This can be one of the following, see their documentation for details:
+
+    * :data:`LOAD_METADATA_TYPE_NEVER`
+    * :data:`LOAD_METADATA_TYPE_ONCE`
+    * :data:`LOAD_METADATA_TYPE_ALWAYS`
+
+    Args:
+        name (str): The string representation of the way to load metadata.
+    """
+
+
+#: Never load metadata.
+LOAD_METADATA_TYPE_NEVER = LoadMetadataType('Never')
+#: Load metadata only at the first time of listing status on a directory.
+LOAD_METADATA_TYPE_ONCE = LoadMetadataType('Once')
+#: Always load metadata when listing status on a directory.
+LOAD_METADATA_TYPE_ALWAYS = LoadMetadataType('Always')
+
+
+def mk_load_metadata_type(name):
+    """
+    Used for `attrs` convertes, during decoding `from_json`. This allows to have the `from_json` avoid doing nested
+    types, such as a `Mode` that contains a `Mode` for the owner_bits attribute.
+    """
+    if isinstance(name, LoadMetadataType):
+        return name
+    return LoadMetadataType(name)
+
+
+@attr.s
+class Mode(Jsonnable):
+    """
+    A file's access mode.
+    """
+
+    owner_bits = attr.ib(default='', converter=Bits)  # (:obj:`alluxio.wire.Bits`): Access mode of the file's owner.
+    group_bits = attr.ib(default='', converter=Bits)  # (:obj:`alluxio.wire.Bits`): Access mode of the users in the
+    # file's group.
+    other_bits = attr.ib(default='', converter=Bits)  # (:obj:`alluxio.wire.Bits`): Access mode of others who are
+    # neither the owner nor in the group.
+
+    member_json_map = {
+        'owner_bits': 'ownerBits',
+        'group_bits': 'groupBits',
+        'other_bits': 'otherBits'
+    }
+
+
+def mk_mode(owner_bits='', group_bits='', other_bits=''):
+    """
+    Used for `attrs` convertes, during decoding `from_json`. This allows to have the `from_json` avoid doing nested
+    types, such as a `Mode` that contains a `Mode` for the owner_bits attribute.
+    """
+    if isinstance(owner_bits, Mode):
+        return owner_bits
+    return Mode(owner_bits=owner_bits, group_bits=group_bits, other_bits=other_bits)

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setup(
     url='https://github.com/Alluxio/alluxio-py',
     author='Alluxio, Inc',
     packages=find_packages(exclude=['docs', 'tests']),
-    install_requires=['six', 'requests'],
+    install_requires=['six', 'requests', 'attrs'],
     tests_require=['pytest', 'pytest-cov']
 )

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,6 @@ deps = pytest
     pylint
 commands =
 # NOTE: you can run any command line tool here - not just tests
-    pytest
+    pytest -vv {posargs}
     flake8
     pylint alluxio


### PR DESCRIPTION
New version uses `attrs` module for relevant classes. Puts `from_json` and `to_json` into the base class. Makes sure that encode/decode is bi-directional. Uses `__dict__` to create a json-serializable dictionary. Modifies `json` to always return valid json string. Updates all test cases as needed. End result should be an easier time adding and extending different operations along with their associated options.