### PR TITLE
Fix typo in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     long_description='Alluxio python client based on REST API',
     url='https://github.com/Alluxio/alluxio-py',
     author='Alluxio, Inc',
-    license="Apache-2.0"
+    license="Apache-2.0",
     packages=find_packages(exclude=['docs', 'tests']),
     install_requires=['six', 'requests'],
     tests_require=['pytest', 'pytest-cov']


### PR DESCRIPTION
`pip install -e .` was failing:

```
    Complete output (6 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/Users/psolomin/private-repos/alluxio-py/setup.py", line 26
        packages=find_packages(exclude=['docs', 'tests']),
        ^
    SyntaxError: invalid syntax
    ----------------------------------------
```