### PR TITLE
Fix doc issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ for docstrings.
 ## Generate Documentation
 
 ```bash
-pip install 'sphinx<1.4' # the latest sphinx has some format issue in the generated html files
+pip install sphinx~=5.0
 cd docs
 make html
 # open docs/_build/html/index.html in your browser

--- a/alluxio/exceptions.py
+++ b/alluxio/exceptions.py
@@ -224,6 +224,7 @@ class FailedPreconditionError(AlluxioError):
     A litmus test that may help a service implementor in deciding between
     :class:`FailedPreconditionException`, :class:`AbortedException`, and
     :class:`UnavailableException`:
+
         (a) Use UnavailableException if the client can retry the failed call.
         (b) Use AbortedException if the client should retry at a higher-level (e.g., restarting a
             read-modify-write sequence).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ release = alluxio.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -163,7 +163,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied


### PR DESCRIPTION
- WARNING: html_static_path entry '_static' does not exist
- Failure of doc generation:

```
$ make html
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v1.3.6
loading translations [en]... done
loading pickled environment... failed: Can't get attribute '_stable_repr_object' on <module 'sphinx.builders.html' from '.../.pyenv/versions/3.9.7/envs/alluxio-py/lib/python3.9/site-packages/sphinx/builders/html.py'>

Exception occurred:
  File ".../.pyenv/versions/3.9.7/envs/alluxio-py/lib/python3.9/site-packages/sphinx/jinja2glue.py", line 16, in <module>
    from jinja2 import FileSystemLoader, BaseLoader, TemplateNotFound, \
ImportError: cannot import name 'contextfunction' from 'jinja2' (.../.pyenv/versions/3.9.7/envs/alluxio-py/lib/python3.9/site-packages/jinja2/__init__.py)
The full traceback has been saved in /var/folders/jh/8yfsyb6j3pz432fj878403cc0000gn/T/sphinx-err-2ixttfbz.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
make: *** [html] Error 1
```

- `.../alluxio-py/alluxio/exceptions.py:docstring of alluxio.exceptions.FailedPreconditionError:8: ERROR: Unexpected indentation.`