### PR TITLE
Add the development guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to alluxio-py
+
+Thanks for your interest in **alluxio-py**. The project is to enable data access to Alluxio in Python.
+
+## Getting Started
+
+We recommend you follow the [readme](README.md) first to get familiar with the project. 
+Contributors would need to install the Python library and dependencies.
+
+## Code Style
+
+The project leverages [Black](https://github.com/psf/black) as the code formatter and [reorder-python-imports](https://github.com/asottile/reorder_python_imports) to format imports.
+Black defaults to 88 characters per line (10% over 80), while this project still uses 80 characters per line. 
+We recommend running the following commands before submitting pull requests.
+
+```bash
+black [changed-file].py --line-length 79
+reorder-python-imports [changed-file].py
+```

--- a/README.md
+++ b/README.md
@@ -107,3 +107,7 @@ Returns:
 print(alluxio.read(full_ufs_file_path))
 ```
 See datasets/alluxio.py AlluxioDataset for more example usage
+
+## Development
+
+See [Contributions](CONTRIBUTING.md) for guidelines around making new contributions and reviewing them.


### PR DESCRIPTION
Add the development guide for the Alluxio python client, generally based on the guide used for the [AI reference architecture](https://github.com/ChunxuTang/AI-Reference-Architecture).