### PR TITLE
Fix path typo in the python client

### DIFF
--- a/alluxio/alluxio_file_system.py
+++ b/alluxio/alluxio_file_system.py
@@ -139,7 +139,6 @@ class AlluxioFileSystem:
             ]
         """
         self._validate_path(path)
-        path_id = self._get_path_hash(path)
         worker_host = self._get_preferred_worker_host(path)
         params = {"path": path}
         try:
@@ -218,7 +217,7 @@ class AlluxioFileSystem:
             except Exception as e:
                 if page_index == 0:
                     raise Exception(
-                        f"Error when reading page 0 of {file_path}: error {e}"
+                        f"Error when reading page 0 of {path_id}: error {e}"
                     ) from e
                 else:
                     # TODO(lu) distinguish end of file exception and real exception
@@ -249,7 +248,7 @@ class AlluxioFileSystem:
             except Exception as e:
                 if page_index == start_page_index:
                     raise Exception(
-                        f"Error when reading page {page_index} of {file_path}: error {e}"
+                        f"Error when reading page {page_index} of {path_id}: error {e}"
                     ) from e
                 else:
                     # TODO(lu) distinguish end of file exception and real exception


### PR DESCRIPTION
This PR fixes a typo related to the file path in the python client.