### PR TITLE
Change to Alluxio 0.3 with protobuf 3.20

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import find_packages
 from setuptools import setup
 
 setup(
-    name="alluxio-python-library",
-    version="0.1",
+    name="alluxio",
+    version="0.3",
     packages=find_packages(exclude=["tests", "tests.*"]),
     include_package_data=True,
     zip_safe=False,
@@ -15,6 +15,7 @@ setup(
         "etcd3",
         "mmh3",
         "sortedcontainers",
+        "protobuf>=3.20.0,<3.21.0",
     ],
     extras_require={"tests": ["pytest", "pytest-aiohttp"]},
     python_requires=">=3.8",


### PR DESCRIPTION
ETCD3 requires protobuf 3.19+ and smaller than 4
https://bugs.launchpad.net/python-tooz/+bug/1980079
which only 3.20.1 3.20.2 3.20.3 fulfill the requirements